### PR TITLE
Token based authentication for the server

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -35,8 +35,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1.19.1)"]
-testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
+testing = ["pytest-timeout (>=2.1)", "pytest-cov (>=3)", "pytest (>=7.1.2)", "coverage (>=6.4.2)", "covdefaults (>=2.2)"]
+docs = ["sphinx-autodoc-typehints (>=1.19.1)", "sphinx (>=5.1.1)", "furo (>=2022.6.21)"]
 
 [[package]]
 name = "flask"
@@ -141,8 +141,22 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
-test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
+test = ["pytest (>=6)", "pytest-mock (>=3.6)", "pytest-cov (>=2.7)", "appdirs (==1.4.4)"]
+docs = ["sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)", "proselint (>=0.10.2)", "furo (>=2021.7.5b38)"]
+
+[[package]]
+name = "pyjwt"
+version = "2.5.0"
+description = "JSON Web Token implementation in Python"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+
+[package.extras]
+crypto = ["cryptography (>=3.3.1)", "types-cryptography (>=3.3.21)"]
+dev = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface", "cryptography (>=3.3.1)", "types-cryptography (>=3.3.21)", "pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)", "pre-commit"]
+docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
+tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
 
 [[package]]
 name = "pyparsing"
@@ -157,7 +171,7 @@ diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.3.0"
+version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
@@ -208,12 +222,12 @@ docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tideli
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-server = ["flask", "marshmallow"]
+server = ["flask", "marshmallow", "pyjwt"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7"
-content-hash = "bb4cc7d7d3c1e0f5f871d907480f8528cf56a1c415000f4618ad9c80df5fe242"
+content-hash = "1cda82c58809824664cd521c4f654777e15e73d23de8004062c50ac8b0148a25"
 
 [metadata.files]
 click = [
@@ -302,13 +316,17 @@ platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
     {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
 ]
+pyjwt = [
+    {file = "PyJWT-2.5.0-py3-none-any.whl", hash = "sha256:8d82e7087868e94dd8d7d418e5088ce64f7daab4b36db654cbaedb46f9d1ca80"},
+    {file = "PyJWT-2.5.0.tar.gz", hash = "sha256:e77ab89480905d86998442ac5788f35333fa85f65047a534adc38edf3c88fc3b"},
+]
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
-    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
 ]
 virtualenv = [
     {file = "virtualenv-20.16.5-py3-none-any.whl", hash = "sha256:d07dfc5df5e4e0dbc92862350ad87a36ed505b978f6c39609dc489eadd5b0d27"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,10 @@ virtualenv = ">=20.4"
 importlib-metadata = ">=4.4"
 flask = { version = "*", optional = true }
 marshmallow = { version = "*", optional = true }
+pyjwt = { version = "*", optional = true }
 
 [tool.poetry.extras]
-server = ["flask", "marshmallow"]
+server = ["flask", "marshmallow", "pyjwt"]
 
 [tool.poetry.plugins."isolate.backends"]
 "virtualenv" = "isolate.backends.virtual_env:VirtualPythonEnvironment"

--- a/src/isolate/server/_auth.py
+++ b/src/isolate/server/_auth.py
@@ -10,7 +10,7 @@ def validate_auth_token(token: str, user_key: str, secret_key: str) -> bool:
     # Decode user_key from JWT
     try:
         decoded = jwt.decode(token, secret_key, algorithms=[ALGORITHM])
-        decoded_key = decoded['key']
-        return user_key == decoded_key
-    except Exception:
+    except jwt.PyJWTError:
         return False
+    else:
+        return user_key == decoded.get('key')

--- a/src/isolate/server/_auth.py
+++ b/src/isolate/server/_auth.py
@@ -10,7 +10,7 @@ def validate_auth_token(token: str, user_key: str, secret_key: str) -> bool:
     # Decode user_key from JWT
     try:
         decoded = jwt.decode(token, secret_key, algorithms=[ALGORITHM])
-        decoded_key = decoded['user_key']
+        decoded_key = decoded['key']
         return user_key == decoded_key
-    except:
-        raise jwt.InvalidTokenError
+    except Exception:
+        return False

--- a/src/isolate/server/_auth.py
+++ b/src/isolate/server/_auth.py
@@ -1,0 +1,16 @@
+import jwt
+
+ALGORITHM = 'HS256'
+
+def create_auth_token(user_key: str, secret_key: str) -> str:
+    # Encode user_key in a JWT
+    return jwt.encode({'key': user_key}, secret_key, ALGORITHM)
+
+def validate_auth_token(token: str, user_key: str, secret_key: str) -> bool:
+    # Decode user_key from JWT
+    try:
+        decoded = jwt.decode(token, secret_key, algorithms=[ALGORITHM])
+        decoded_key = decoded['user_key']
+        return user_key == decoded_key
+    except:
+        raise jwt.InvalidTokenError

--- a/src/isolate/server/_server.py
+++ b/src/isolate/server/_server.py
@@ -49,19 +49,20 @@ def check_auth(f):
     @wraps(f)
     def decorator(*args, **kwargs):
         token = None
-        if 'x-access-token' in request.headers:
-            token = request.headers['x-access-token']
-            if validate_auth_token(
-                    token,
-                    app.config["USER_NAME"],
-                    app.config["SECRET_KEY"]):
-                return f(*args, **kwargs)
+        if app.config.get('USER_NAME', False):
+            if 'x-access-token' in request.headers:
+                token = request.headers['x-access-token']
+                if validate_auth_token(
+                        token,
+                        app.config["USER_NAME"],
+                        app.config["SECRET_KEY"]):
+                    return f(*args, **kwargs)
+                else:
+                    return error(code=401, message="Invalid token")
             else:
-                return error(code=401, message="Invalid token")
-
-        if not token and app.config.get("USER_NAME", False):
-            return error(code=401, message="Isolate server is configured with the authentication mode, but no authentication token was passed")
-            ```
+                return error(
+                    code=401,
+                    message="Isolate server is configured with the authentication mode, but no authentication token was passed")
 
         return f(*args, **kwargs)
 

--- a/src/isolate/server/_server.py
+++ b/src/isolate/server/_server.py
@@ -53,8 +53,8 @@ def check_auth(f):
             token = request.headers['x-access-token']
             if validate_auth_token(
                     token,
-                    app.config.get("USER_NAME", False),
-                    app.config.get("SECRET_KEY", False)):
+                    app.config["USER_NAME"],
+                    app.config["SECRET_KEY"]):
                 return f(*args, **kwargs)
             else:
                 return error(code=401, message="Invalid token")

--- a/src/isolate/server/_server.py
+++ b/src/isolate/server/_server.py
@@ -60,7 +60,8 @@ def check_auth(f):
                 return error(code=401, message="Invalid token")
 
         if not token and app.config.get("USER_NAME", False):
-            return error(code=401, message="A valid token is missing")
+            return error(code=401, message="Isolate server is configured with the authentication mode, but no authentication token was passed")
+            ```
 
         return f(*args, **kwargs)
 

--- a/src/isolate/server/_server.py
+++ b/src/isolate/server/_server.py
@@ -20,6 +20,7 @@ from isolate.server._utils import (
     success,
     wrap_validation_errors,
 )
+from isolate.server._auth import create_auth_token
 
 app = Flask(__name__)
 
@@ -27,6 +28,19 @@ app = Flask(__name__)
 ENV_STORE: Dict[str, BaseEnvironment] = {}
 RUN_STORE: Dict[str, RunInfo] = {}
 MAX_JOIN_WAIT = 1
+
+app.config.from_prefixed_env("FAL")
+
+if app.config.get('USER_NAME', False):
+    app.config['SECRET_KEY'] = secrets.token_urlsafe()
+    app.config['AUTH_TOKEN'] = create_auth_token(
+        app.config['USER_NAME'],
+        app.config['SECRET_KEY'])
+
+    print("++++")
+    print("The following line contains your authentication token. Put it in 'x-access-token' header.")
+    print(app.config['AUTH_TOKEN'])
+    print("++++")
 
 
 @app.route("/environments/create", methods=["POST"])
@@ -100,3 +114,4 @@ def get_run_status(token):
         is_done=run_info.is_done,
         logs=[log.serialize() for log in new_logs],
     )
+

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -195,7 +195,7 @@ def test_isolate_server_auth_error(
     inherit_from_local(monkeypatch)
 
     # Activates authentication requirement
-    app.config['USER_NAME'] = "testuser"
+    monkeypatch.setitem(app.config, 'USER_NAME', 'testuser')
 
     requirements = ["pyjokes==0.6.0"]
 
@@ -212,7 +212,7 @@ def test_isolate_server_auth_error(
     data = response.json
 
     assert data["status"] == "error"
-    assert data["message"] == "A valid token is missing"
+    assert data["message"] == "Isolate server is configured with the authentication mode, but no authentication token was passed"
 
 
 def test_isolate_server_auth_invalid_token(
@@ -222,7 +222,7 @@ def test_isolate_server_auth_invalid_token(
     inherit_from_local(monkeypatch)
 
     # Activates authentication requirement
-    app.config['USER_NAME'] = "testuser"
+    monkeypatch.setitem(app.config, 'USER_NAME', 'testuser')
 
     requirements = ["pyjokes==0.6.0"]
 
@@ -253,8 +253,8 @@ def test_isolate_server_auth(
     inherit_from_local(monkeypatch)
 
     # Activates authentication requirement
-    app.config["USER_NAME"] = "testuser"
-    app.config["SECRET_KEY"] = "testkey"
+    monkeypatch.setitem(app.config, 'USER_NAME', 'testuser')
+    monkeypatch.setitem(app.config, 'SECRET_KEY', 'testkey')
 
     token = create_auth_token(app.config['USER_NAME'], app.config['SECRET_KEY'])
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -186,3 +186,91 @@ def test_environment_building_error(api_wrapper: APIWrapper, monkeypatch: Any) -
         "Failed to create the environment. Aborting the run.",
     )
     assert not user_logs
+
+
+def test_isolate_server_auth_error(
+    api_wrapper: APIWrapper,
+    monkeypatch: Any,
+) -> None:
+    inherit_from_local(monkeypatch)
+
+    # Activates authentication requirement
+    app.config['USER_NAME'] = "testuser"
+
+    requirements = ["pyjokes==0.6.0"]
+
+    response = api_wrapper.client.post(
+        "/environments/create",
+        json={
+            "kind": "virtualenv",
+            "configuration": {'requirements': requirements}
+        },
+    )
+
+    assert response.status_code == 401
+
+    data = response.json
+
+    assert data["status"] == "error"
+    assert data["message"] == "A valid token is missing"
+
+
+def test_isolate_server_auth_invalid_token(
+    api_wrapper: APIWrapper,
+    monkeypatch: Any,
+) -> None:
+    inherit_from_local(monkeypatch)
+
+    # Activates authentication requirement
+    app.config['USER_NAME'] = "testuser"
+
+    requirements = ["pyjokes==0.6.0"]
+
+    response = api_wrapper.client.post(
+        "/environments/create",
+        headers={
+            "x-access-token": "invalid token"
+        },
+        json={
+            "kind": "virtualenv",
+            "configuration": {'requirements': requirements}
+        },
+    )
+
+    assert response.status_code == 401
+
+    data = response.json
+
+    assert data["status"] == "error"
+    assert data["message"] == "Invalid token"
+
+
+def test_isolate_server_auth(
+    api_wrapper: APIWrapper,
+    monkeypatch: Any,
+) -> None:
+    from isolate.server._auth import create_auth_token
+    inherit_from_local(monkeypatch)
+
+    # Activates authentication requirement
+    app.config["USER_NAME"] = "testuser"
+    app.config["SECRET_KEY"] = "testkey"
+
+    token = create_auth_token(app.config['USER_NAME'], app.config['SECRET_KEY'])
+
+    requirements = ["pyjokes==0.6.0"]
+
+    response = api_wrapper.client.post(
+        "/environments/create",
+        headers={
+            "x-access-token": token
+        },
+        json={
+            "kind": "virtualenv",
+            "configuration": {'requirements': requirements}
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json["status"] == 'success'
+


### PR DESCRIPTION
Adds token based authentication to the Flask server

Features:
- Authentication off by default
- If `FAL_USER_NAME` is set, authentication is required
- Server prints out a token when it's started
- All requests must then include `x-access-token` header that contains a valid token

Example:
```
docker run -p 5000:5000 --env FAL_USER_NAME=testotesto falai/isolate
```
Prints out following:
```
++++
The following line contains your authentication token. Put it in 'x-access-token' header.
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ0ZXN0b3Rlc3RvIn0.RSORaI4bxkjNNU-LHaXEL1OSK5K1bXJx448aG4_ocBo
++++
 * Serving Flask app 'isolate.server'
 * Debug mode: off
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on all addresses (0.0.0.0)
 * Running on http://127.0.0.1:5000
 * Running on http://172.17.0.2:5000
```
