### PR TITLE
fix: validate invalid parameters when initializing environments

### DIFF
--- a/src/isolate/backends/conda.py
+++ b/src/isolate/backends/conda.py
@@ -4,7 +4,7 @@ import functools
 import os
 import shutil
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List
 
@@ -23,7 +23,7 @@ _ISOLATE_CONDA_HOME = os.getenv("ISOLATE_CONDA_HOME")
 class CondaEnvironment(BaseEnvironment[Path]):
     BACKEND_NAME: ClassVar[str] = "conda"
 
-    packages: List[str]
+    packages: List[str] = field(default_factory=list)
 
     @classmethod
     def from_config(
@@ -31,8 +31,7 @@ class CondaEnvironment(BaseEnvironment[Path]):
         config: Dict[str, Any],
         settings: IsolateSettings = DEFAULT_SETTINGS,
     ) -> BaseEnvironment:
-        user_provided_packages = config.get("packages", [])
-        environment = cls(user_provided_packages)
+        environment = cls(**config)
         environment.apply_settings(settings)
         return environment
 

--- a/src/isolate/backends/local.py
+++ b/src/isolate/backends/local.py
@@ -21,7 +21,7 @@ class LocalPythonEnvironment(BaseEnvironment[Path]):
         config: Dict[str, Any],
         settings: IsolateSettings = DEFAULT_SETTINGS,
     ) -> BaseEnvironment:
-        environment = cls()
+        environment = cls(**config)
         environment.apply_settings(settings)
         return environment
 

--- a/src/isolate/backends/remote.py
+++ b/src/isolate/backends/remote.py
@@ -36,11 +36,7 @@ class IsolateServer(BaseEnvironment[EnvironmentDefinition]):
         config: Dict[str, Any],
         settings: IsolateSettings = DEFAULT_SETTINGS,
     ) -> BaseEnvironment:
-        environment = cls(
-            host=config["host"],
-            target_environment_kind=config["target_environment_kind"],
-            target_environment_config=config["target_environment_config"],
-        )
+        environment = cls(**config)
         environment.apply_settings(settings)
 
         return environment

--- a/src/isolate/backends/virtualenv.py
+++ b/src/isolate/backends/virtualenv.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional, Union
 
@@ -21,7 +21,7 @@ from isolate.connections import PythonIPC
 class VirtualPythonEnvironment(BaseEnvironment[Path]):
     BACKEND_NAME: ClassVar[str] = "virtualenv"
 
-    requirements: List[str]
+    requirements: List[str] = field(default_factory=list)
     constraints_file: Optional[os.PathLike] = None
 
     @classmethod
@@ -30,13 +30,7 @@ class VirtualPythonEnvironment(BaseEnvironment[Path]):
         config: Dict[str, Any],
         settings: IsolateSettings = DEFAULT_SETTINGS,
     ) -> BaseEnvironment:
-        requirements = config.get("requirements", [])
-        # TODO: we probably should validate that this file actually exists
-        constraints_file = config.get("constraints_file", None)
-        environment = cls(
-            requirements=requirements,
-            constraints_file=constraints_file,
-        )
+        environment = cls(**config)
         environment.apply_settings(settings)
         return environment
 

--- a/src/isolate/server/server.py
+++ b/src/isolate/server/server.py
@@ -41,9 +41,14 @@ class IsolateServicer(definitions.IsolateServicer):
         messages: Queue[definitions.PartialRunResult] = Queue()
         try:
             environment = from_grpc(request.environment)
-        except ValueError as exc:
+        except ValueError:
             return self.abort_with_msg(
                 f"Unknown environment kind: {request.environment.kind}.",
+                context,
+            )
+        except TypeError as exc:
+            return self.abort_with_msg(
+                f"Invalid environment parameter: {str(exc)}.",
                 context,
             )
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -381,3 +381,42 @@ def test_isolate_server_demo(isolate_server):
                 assert local_connection.run(target_func) == remote_connection.run(
                     target_func
                 )
+
+
+@pytest.mark.parametrize(
+    "kind, config",
+    [
+        (
+            "virtualenv",
+            {
+                "packages": [
+                    "pyjokes==1.0.0",
+                ]
+            },
+        ),
+        (
+            "conda",
+            {
+                "requirements": [
+                    "pyjokes=1.0.0",
+                ]
+            },
+        ),
+        (
+            "isolate-server",
+            {
+                "host": "localhost",
+                "port": 1234,
+                "target_environment_kind": "virtualenv",
+                "target_environment_config": {
+                    "requirements": [
+                        "pyjokes==1.0.0",
+                    ]
+                },
+            },
+        ),
+    ],
+)
+def test_wrong_options(kind, config):
+    with pytest.raises(TypeError):
+        isolate.prepare_environment(kind, **config)


### PR DESCRIPTION
No more confusion when `virtualenv with packages=[]` didn't install anything 🎉 