### PR TITLE
fix: high parallelism safe atomic cache locking

### DIFF
--- a/src/isolate/backends/settings.py
+++ b/src/isolate/backends/settings.py
@@ -51,6 +51,12 @@ class IsolateSettings:
         path.mkdir(exist_ok=True, parents=True)
         return path
 
+    def _get_lock_dir(self) -> Path:
+        """Return a directory which can be used for storing file-based locks."""
+        lock_dir = self._get_temp_base() / "locks"
+        lock_dir.mkdir(exist_ok=True, parents=True)
+        return lock_dir
+
     @contextmanager
     def build_ctx_for(self, dst_path: Path) -> Iterator[Path]:
         """Create a new build context for the given 'dst_path'. It will return
@@ -65,7 +71,7 @@ class IsolateSettings:
             shutil.rmtree(tmp_path)
             raise exc
         else:
-            replace_dir(tmp_path, dst_path)
+            replace_dir(tmp_path, dst_path, self._get_lock_dir())
 
     def cache_dir_for(self, backend: BaseEnvironment) -> Path:
         """Return a directory which can be used for caching the given

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,7 +1,12 @@
+from multiprocessing import Process
+
 from isolate.backends.common import replace_dir
 
 
 def test_replace_dir(tmp_path):
+    lock_dir = tmp_path / "lock"
+    lock_dir.mkdir()
+
     src_path = tmp_path / "src"
     src_path.mkdir()
 
@@ -10,7 +15,7 @@ def test_replace_dir(tmp_path):
     (src_path / "subdir" / "file").write_text("hello")
 
     dst_path = tmp_path / "dst"
-    replace_dir(src_path, dst_path)
+    replace_dir(src_path, dst_path, lock_dir)
     assert not src_path.exists()
     assert dst_path.exists()
     assert (dst_path / "file").read_text() == "hello"
@@ -18,6 +23,9 @@ def test_replace_dir(tmp_path):
 
 
 def test_replace_dir_with_existing_dst(tmp_path):
+    lock_dir = tmp_path / "lock"
+    lock_dir.mkdir()
+
     src_path = tmp_path / "src"
     src_path.mkdir()
 
@@ -33,8 +41,45 @@ def test_replace_dir_with_existing_dst(tmp_path):
     (dst_path / "subdir").mkdir()
     (dst_path / "subdir" / "file").write_text("hello")
 
-    replace_dir(src_path, dst_path)
+    replace_dir(src_path, dst_path, lock_dir)
     assert not src_path.exists()
     assert dst_path.exists()
     assert (dst_path / "file").read_text() == "hello"
     assert (dst_path / "subdir" / "file").read_text() == "hello"
+
+
+def replace_on_process(*args, timeout=0.5):
+    process = Process(target=replace_dir, args=args)
+    process.start()
+    process.join(timeout=timeout)
+    process.kill()
+    process.join()
+    assert not process.is_alive()
+
+
+def test_await_lock(tmp_path):
+    from isolate.backends.common import _lock_file_for
+
+    lock_dir = tmp_path / "lock"
+    lock_dir.mkdir()
+
+    src_path = tmp_path / "src"
+    src_path.mkdir()
+
+    (src_path / "file").write_text("hello")
+
+    dst_path = tmp_path / "dst"
+    dst_path.mkdir()
+
+    # Try locking the dst_path
+    with _lock_file_for(dst_path, lock_dir):
+        # And now try replacing it (should fail because the lock is held)
+        replace_on_process(src_path, dst_path, lock_dir)
+        assert not (dst_path / "file").exists()
+
+    assert src_path.exists()
+    assert dst_path.exists()
+
+    # but if we release the lock, it should work
+    replace_on_process(src_path, dst_path, lock_dir)
+    assert (dst_path / "file").exists(), list(dst_path.iterdir())


### PR DESCRIPTION
Even though we had a good solution for dealing with this in the past, I've observed that it is not enough when we start a lot of different processes. The main problem is that we had to do two renames and in the midst from one to the other there might be other processes moving the environment. This PR moves this system to a more granular, lock based approach which should guarantee that a particular cache directory will only be modified by a single process at a time.