### PR TITLE
fix: Ensure conda environments are moved properly

### DIFF
--- a/src/isolate/backends/conda.py
+++ b/src/isolate/backends/conda.py
@@ -44,7 +44,9 @@ class CondaEnvironment(BaseEnvironment[Path]):
         if env_path.exists():
             return env_path
 
-        with self.settings.build_ctx_for(env_path) as build_path:
+        with self.settings.build_ctx_for(
+            env_path, environment_move_hook=self._rename_conda_env
+        ) as build_path:
             self.log(f"Creating the environment at '{build_path}'")
             conda_executable = _get_conda_executable()
             if self.packages:
@@ -74,6 +76,32 @@ class CondaEnvironment(BaseEnvironment[Path]):
         assert env_path.exists(), "Environment must be built at this point"
         self.log(f"New environment cached at '{env_path}'")
         return env_path
+
+    def _rename_conda_env(self, src_path: Path, dst_path: Path) -> None:
+        # Simply renaming the src_path to dst_path is not enough
+        # for conda, since there might be some binaries built with
+        # the assumption that the some libraries are located inside
+        # src_path (even after it doesn't exist anymore).
+
+        self.log(f"Renaming the environment from '{src_path}' to '{dst_path}'")
+        with logged_io(self.log) as (stdout, stderr):
+            conda_executable = _get_conda_executable()
+
+            # Note: newer versions of conda have a `conda
+            # rename` command, but it is not commonly available.
+            subprocess.check_call(
+                [
+                    conda_executable,
+                    "create",
+                    "--yes",
+                    "--prefix",
+                    dst_path,
+                    "--clone",
+                    src_path,
+                ],
+                stdout=stdout,
+                stderr=stderr,
+            )
 
     def destroy(self, connection_key: Path) -> None:
         shutil.rmtree(connection_key)

--- a/src/isolate/backends/settings.py
+++ b/src/isolate/backends/settings.py
@@ -5,7 +5,7 @@ import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Iterator
+from typing import TYPE_CHECKING, Any, Callable, Iterator
 
 from platformdirs import user_cache_dir
 
@@ -58,7 +58,7 @@ class IsolateSettings:
         return lock_dir
 
     @contextmanager
-    def build_ctx_for(self, dst_path: Path) -> Iterator[Path]:
+    def build_ctx_for(self, dst_path: Path, **replace_args: Any) -> Iterator[Path]:
         """Create a new build context for the given 'dst_path'. It will return
         a temporary directory which can be used to create the environment and
         once the context is closed, the build directory will be moved to
@@ -71,7 +71,7 @@ class IsolateSettings:
             shutil.rmtree(tmp_path)
             raise exc
         else:
-            replace_dir(tmp_path, dst_path, self._get_lock_dir())
+            replace_dir(tmp_path, dst_path, self._get_lock_dir(), **replace_args)
 
     def cache_dir_for(self, backend: BaseEnvironment) -> Path:
         """Return a directory which can be used for caching the given

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -58,7 +58,7 @@ def replace_on_process(*args, timeout=0.5):
 
 
 def test_await_lock(tmp_path):
-    from isolate.backends.common import _lock_file_for
+    from isolate.backends.common import _lock_path
 
     lock_dir = tmp_path / "lock"
     lock_dir.mkdir()
@@ -72,7 +72,7 @@ def test_await_lock(tmp_path):
     dst_path.mkdir()
 
     # Try locking the dst_path
-    with _lock_file_for(dst_path, lock_dir):
+    with _lock_path(dst_path, lock_dir):
         # And now try replacing it (should fail because the lock is held)
         replace_on_process(src_path, dst_path, lock_dir)
         assert not (dst_path / "file").exists()


### PR DESCRIPTION
Seems like when building the environments from `/tmp/<build-dir>` to `/cache/<cache-id>`, some of the binaries still contain references to the `/tmp/<build-dir>` because of how conda links compiled binaries and their headers. We should be able to use `conda clone` as a proper way of moving the environments which figures out which parts reference a certain base path and then relinks them.