### PR TITLE
feat: add log level comparison

### DIFF
--- a/src/isolate/connections/grpc/interface.py
+++ b/src/isolate/connections/grpc/interface.py
@@ -36,7 +36,7 @@ def _(message: definitions.SerializedObject) -> Any:
 @from_grpc.register
 def _(message: definitions.Log) -> Log:
     source = LogSource(definitions.LogSource.Name(message.source).lower())
-    level = LogLevel(definitions.LogLevel.Name(message.level).lower())
+    level = LogLevel[definitions.LogLevel.Name(message.level).upper()]
     return Log(
         message=message.message,
         source=source,

--- a/src/isolate/logs.py
+++ b/src/isolate/logs.py
@@ -5,6 +5,7 @@ import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from enum import Enum
+from functools import total_ordering
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Dict, Iterator, NewType, Optional
 
@@ -33,7 +34,8 @@ class LogSource(str, Enum):
     USER = "user"
 
 
-class LogLevel(str, Enum):
+@total_ordering
+class LogLevel(Enum):
     """Represents the log level."""
 
     TRACE = "trace"
@@ -46,6 +48,26 @@ class LogLevel(str, Enum):
     STDOUT = "stdout"
     STDERR = "stderr"
 
+    @property
+    def score(self) -> int:
+        scores: dict[LogLevel, int] = {
+            LogLevel.STDERR: 110,
+            LogLevel.STDOUT: 100,
+            LogLevel.ERROR: 40,
+            LogLevel.WARNING: 30,
+            LogLevel.INFO: 20,
+            LogLevel.DEBUG: 10,
+            LogLevel.TRACE: 0,
+        }
+        return scores[self]
+
+    def __lt__(self, other: LogLevel) -> bool:
+        if self.__class__ is other.__class__:
+            return self.score < other.score
+        return NotImplemented
+
+    def __str__(self) -> str:
+        return self.value
 
 @dataclass
 class Log:

--- a/src/isolate/logs.py
+++ b/src/isolate/logs.py
@@ -38,36 +38,24 @@ class LogSource(str, Enum):
 class LogLevel(Enum):
     """Represents the log level."""
 
-    TRACE = "trace"
-    DEBUG = "debug"
-    INFO = "info"
-    WARNING = "warning"
-    ERROR = "error"
+    TRACE = 0
+    DEBUG = 10
+    INFO = 20
+    WARNING = 30
+    ERROR = 40
 
     # For user scripts
-    STDOUT = "stdout"
-    STDERR = "stderr"
-
-    @property
-    def score(self) -> int:
-        scores: dict[LogLevel, int] = {
-            LogLevel.STDERR: 110,
-            LogLevel.STDOUT: 100,
-            LogLevel.ERROR: 40,
-            LogLevel.WARNING: 30,
-            LogLevel.INFO: 20,
-            LogLevel.DEBUG: 10,
-            LogLevel.TRACE: 0,
-        }
-        return scores[self]
+    STDOUT = 100
+    STDERR = 110
 
     def __lt__(self, other: LogLevel) -> bool:
         if self.__class__ is other.__class__:
-            return self.score < other.score
+            return self.value < other.value
         return NotImplemented
 
     def __str__(self) -> str:
-        return self.value
+        return self.name.lower()
+
 
 @dataclass
 class Log:

--- a/tests/test_loglevel.py
+++ b/tests/test_loglevel.py
@@ -1,0 +1,11 @@
+import pytest
+
+from isolate.logs import LogLevel
+
+
+def test_level_gt_comparison():
+    assert LogLevel.INFO > LogLevel.DEBUG
+
+
+def test_level_lt_comparison():
+    assert LogLevel.WARNING < LogLevel.ERROR

--- a/tests/test_loglevel.py
+++ b/tests/test_loglevel.py
@@ -1,5 +1,6 @@
 import pytest
 
+from isolate.connections.grpc import definitions
 from isolate.logs import LogLevel
 
 
@@ -9,3 +10,13 @@ def test_level_gt_comparison():
 
 def test_level_lt_comparison():
     assert LogLevel.WARNING < LogLevel.ERROR
+
+
+def test_level_str():
+    assert str(LogLevel.INFO) == "info"
+
+
+def test_log_definition_conversion():
+    message = definitions.Log(message="message", source=0, level=3)
+    level_definition = definitions.LogLevel.Name(message.level)
+    assert LogLevel[level_definition.upper()] == LogLevel.WARNING


### PR DESCRIPTION
**Notes:**

This small change on the `LogLevel` enum was done to allow comparison between log levels so we can do log filtering when needed.

**Implementation details:**

- Remove the inheritance from `str` to allow custom comparison using `functools.total_ordering`.
- As far as I could assess, this is not a breaking change. The `__str__` is compatible with the previous assumption that the type was also a string. **However, errors might pop up** in case some consuming code assumed the type itself to also be a `str`.

If you have concerns with this approach, please leave a comment!

---

see https://github.com/fal-ai/fal-isolate-cloud/pull/272 for a related change that depends on log level comparison