### PR TITLE
wip: xxx: introduce a way to submit and listen isolated calls

### DIFF
--- a/src/isolate/server/definitions/server.proto
+++ b/src/isolate/server/definitions/server.proto
@@ -7,6 +7,9 @@ service Isolate {
     // Run the given function on the specified environment. Streams logs
     // and the result originating from that function.
     rpc Run (BoundFunction) returns (stream PartialRunResult) {}
+
+    // Submit a function to be run with callbacks for the logs and the result.
+    rpc Submit (SubmitRequest) returns (SubmitResponse) {}
 }
 
 message BoundFunction {
@@ -22,4 +25,22 @@ message EnvironmentDefinition {
     google.protobuf.Struct configuration = 2;
     // Whether to force-create this environment or not.
     bool force = 3;
+}
+
+message SubmitRequest {
+    // The function to run.
+    BoundFunction function = 1;
+
+    // The HTTP callback to call with every partial result. It will be a POST request
+    // with serialized PartialRunResult(s) as the body.
+    string callback = 2;
+}
+
+message SubmitResponse {
+    // Reserved for future use.
+}
+
+message PartialRunResults {
+    // The results of the function.
+    repeated PartialRunResult results = 1;
 }

--- a/src/isolate/server/definitions/server_pb2.py
+++ b/src/isolate/server/definitions/server_pb2.py
@@ -17,18 +17,25 @@ from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 from isolate.connections.grpc.definitions import common_pb2 as common__pb2
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x0cserver.proto\x1a\x0c\x63ommon.proto\x1a\x1cgoogle/protobuf/struct.proto"\x9d\x01\n\rBoundFunction\x12,\n\x0c\x65nvironments\x18\x01 \x03(\x0b\x32\x16.EnvironmentDefinition\x12#\n\x08\x66unction\x18\x02 \x01(\x0b\x32\x11.SerializedObject\x12*\n\nsetup_func\x18\x03 \x01(\x0b\x32\x11.SerializedObjectH\x00\x88\x01\x01\x42\r\n\x0b_setup_func"d\n\x15\x45nvironmentDefinition\x12\x0c\n\x04kind\x18\x01 \x01(\t\x12.\n\rconfiguration\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\r\n\x05\x66orce\x18\x03 \x01(\x08\x32\x37\n\x07Isolate\x12,\n\x03Run\x12\x0e.BoundFunction\x1a\x11.PartialRunResult"\x00\x30\x01\x62\x06proto3'
+    b'\n\x0cserver.proto\x1a\x0c\x63ommon.proto\x1a\x1cgoogle/protobuf/struct.proto"\x9d\x01\n\rBoundFunction\x12,\n\x0c\x65nvironments\x18\x01 \x03(\x0b\x32\x16.EnvironmentDefinition\x12#\n\x08\x66unction\x18\x02 \x01(\x0b\x32\x11.SerializedObject\x12*\n\nsetup_func\x18\x03 \x01(\x0b\x32\x11.SerializedObjectH\x00\x88\x01\x01\x42\r\n\x0b_setup_func"d\n\x15\x45nvironmentDefinition\x12\x0c\n\x04kind\x18\x01 \x01(\t\x12.\n\rconfiguration\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\r\n\x05\x66orce\x18\x03 \x01(\x08"C\n\rSubmitRequest\x12 \n\x08\x66unction\x18\x01 \x01(\x0b\x32\x0e.BoundFunction\x12\x10\n\x08\x63\x61llback\x18\x02 \x01(\t"\x10\n\x0eSubmitResponse"7\n\x11PartialRunResults\x12"\n\x07results\x18\x01 \x03(\x0b\x32\x11.PartialRunResult2d\n\x07Isolate\x12,\n\x03Run\x12\x0e.BoundFunction\x1a\x11.PartialRunResult"\x00\x30\x01\x12+\n\x06Submit\x12\x0e.SubmitRequest\x1a\x0f.SubmitResponse"\x00\x62\x06proto3'
 )
 
-_builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
-_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "server_pb2", globals())
+_globals = globals()
+_builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
+_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "server_pb2", _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
 
     DESCRIPTOR._options = None
-    _BOUNDFUNCTION._serialized_start = 61
-    _BOUNDFUNCTION._serialized_end = 218
-    _ENVIRONMENTDEFINITION._serialized_start = 220
-    _ENVIRONMENTDEFINITION._serialized_end = 320
-    _ISOLATE._serialized_start = 322
-    _ISOLATE._serialized_end = 377
+    _globals["_BOUNDFUNCTION"]._serialized_start = 61
+    _globals["_BOUNDFUNCTION"]._serialized_end = 218
+    _globals["_ENVIRONMENTDEFINITION"]._serialized_start = 220
+    _globals["_ENVIRONMENTDEFINITION"]._serialized_end = 320
+    _globals["_SUBMITREQUEST"]._serialized_start = 322
+    _globals["_SUBMITREQUEST"]._serialized_end = 389
+    _globals["_SUBMITRESPONSE"]._serialized_start = 391
+    _globals["_SUBMITRESPONSE"]._serialized_end = 407
+    _globals["_PARTIALRUNRESULTS"]._serialized_start = 409
+    _globals["_PARTIALRUNRESULTS"]._serialized_end = 464
+    _globals["_ISOLATE"]._serialized_start = 466
+    _globals["_ISOLATE"]._serialized_end = 566
 # @@protoc_insertion_point(module_scope)

--- a/src/isolate/server/definitions/server_pb2.pyi
+++ b/src/isolate/server/definitions/server_pb2.pyi
@@ -105,3 +105,69 @@ class EnvironmentDefinition(google.protobuf.message.Message):
     ) -> None: ...
 
 global___EnvironmentDefinition = EnvironmentDefinition
+
+@typing_extensions.final
+class SubmitRequest(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    FUNCTION_FIELD_NUMBER: builtins.int
+    CALLBACK_FIELD_NUMBER: builtins.int
+    @property
+    def function(self) -> global___BoundFunction:
+        """The function to run."""
+    callback: builtins.str
+    """The HTTP callback to call with every partial result. It will be a POST request
+    with serialized PartialRunResult(s) as the body.
+    """
+    def __init__(
+        self,
+        *,
+        function: global___BoundFunction | None = ...,
+        callback: builtins.str = ...,
+    ) -> None: ...
+    def HasField(
+        self, field_name: typing_extensions.Literal["function", b"function"]
+    ) -> builtins.bool: ...
+    def ClearField(
+        self,
+        field_name: typing_extensions.Literal[
+            "callback", b"callback", "function", b"function"
+        ],
+    ) -> None: ...
+
+global___SubmitRequest = SubmitRequest
+
+@typing_extensions.final
+class SubmitResponse(google.protobuf.message.Message):
+    """Reserved for future use."""
+
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    def __init__(
+        self,
+    ) -> None: ...
+
+global___SubmitResponse = SubmitResponse
+
+@typing_extensions.final
+class PartialRunResults(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    RESULTS_FIELD_NUMBER: builtins.int
+    @property
+    def results(
+        self,
+    ) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[
+        common_pb2.PartialRunResult
+    ]:
+        """The results of the function."""
+    def __init__(
+        self,
+        *,
+        results: collections.abc.Iterable[common_pb2.PartialRunResult] | None = ...,
+    ) -> None: ...
+    def ClearField(
+        self, field_name: typing_extensions.Literal["results", b"results"]
+    ) -> None: ...
+
+global___PartialRunResults = PartialRunResults

--- a/src/isolate/server/definitions/server_pb2_grpc.py
+++ b/src/isolate/server/definitions/server_pb2_grpc.py
@@ -20,6 +20,11 @@ class IsolateStub(object):
             request_serializer=server__pb2.BoundFunction.SerializeToString,
             response_deserializer=common__pb2.PartialRunResult.FromString,
         )
+        self.Submit = channel.unary_unary(
+            "/Isolate/Submit",
+            request_serializer=server__pb2.SubmitRequest.SerializeToString,
+            response_deserializer=server__pb2.SubmitResponse.FromString,
+        )
 
 
 class IsolateServicer(object):
@@ -33,6 +38,12 @@ class IsolateServicer(object):
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
+    def Submit(self, request, context):
+        """Submit a function to be run with callbacks for the logs and the result."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
+
 
 def add_IsolateServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -40,6 +51,11 @@ def add_IsolateServicer_to_server(servicer, server):
             servicer.Run,
             request_deserializer=server__pb2.BoundFunction.FromString,
             response_serializer=common__pb2.PartialRunResult.SerializeToString,
+        ),
+        "Submit": grpc.unary_unary_rpc_method_handler(
+            servicer.Submit,
+            request_deserializer=server__pb2.SubmitRequest.FromString,
+            response_serializer=server__pb2.SubmitResponse.SerializeToString,
         ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -71,6 +87,35 @@ class Isolate(object):
             "/Isolate/Run",
             server__pb2.BoundFunction.SerializeToString,
             common__pb2.PartialRunResult.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+        )
+
+    @staticmethod
+    def Submit(
+        request,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        insecure=False,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            "/Isolate/Submit",
+            server__pb2.SubmitRequest.SerializeToString,
+            server__pb2.SubmitResponse.FromString,
             options,
             channel_credentials,
             insecure,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -693,9 +693,9 @@ def test_server_proper_error_delegation(
         run_function(stub, send_unserializable_object, log_handler=user_logs)
 
     assert exc_info.value.code() == grpc.StatusCode.INVALID_ARGUMENT
-    assert exc_info.value.details() == (
-        "Error while serializing the execution result "
-        "(object of type <class 'frame'>)."
+    assert (
+        "Error while serializing the execution result (object of type <class 'frame'>)."
+        in exc_info.value.details()
     )
     assert not user_logs
 
@@ -704,10 +704,10 @@ def test_server_proper_error_delegation(
         run_function(stub, raise_unserializable_object, log_handler=user_logs)
 
     assert exc_info.value.code() == grpc.StatusCode.INVALID_ARGUMENT
-    assert exc_info.value.details() == (
+    assert (
         "Error while serializing the execution result "
         "(object of type <class 'Exception'>)."
-    )
+    ) in exc_info.value.details()
     assert "relevant information" in "\n".join(log.message for log in user_logs)
 
 
@@ -724,10 +724,10 @@ def test_server_submit(
     )
     stub.Submit(request)
 
-    partial_results: list[definitions.PartialRunResult] = []
+    partial_results: List[definitions.PartialRunResult] = []
     while not any(pr.is_complete for pr in partial_results):
         try:
-            message = http_server.messages.get(timeout=10)
+            message = http_server.messages.get(timeout=120)
         except queue.Empty:
             raise ValueError("No message received from the server within 5 seconds")
 


### PR DESCRIPTION
The idea underneath is, currently for every isolate run, you basically need two peers (a client and a server) which makes both sides hold state without a good reason. For the world of HTTP servers, we can essentially fire-and-forget (which is not a good name for this stuff where we actually care about the status of the task) them and let the gateway itself hold as little state/connections as possible.

For achieving this goal quickly, this PR proposes a `Submit` endpoint in addition to the existing `Run` endpoint in the isolate server where you can fire a task and pass a callback which will be used to communicate the logs and the results back. This is still a bit fragile (especially without any sort of fault tolarance on when the callback URL fails) and might be even slower (plain HTTP 🤢) but all of these properties can be improved upon once we are confident in the architecture. The main goal here is to provide the most basic form of fire-and-forget mechanism to isolate where we can start using and experimenting with it on the server and eventually make it nicer. 