### PR TITLE
fix(conda): use --yes instead of --force

### DIFF
--- a/src/isolate/backends/conda.py
+++ b/src/isolate/backends/conda.py
@@ -161,7 +161,7 @@ class CondaEnvironment(BaseEnvironment[Path]):
     def _run_create(self, env_path: str, env_name: str) -> None:
         if self._exec_command == "conda":
             self._run_conda(
-                "env", "create", "--force", "--prefix", env_path, "-f", env_name
+                "env", "create", "--yes", "--prefix", env_path, "-f", env_name
             )
         else:
             self._run_conda("env", "create", "--prefix", env_path, "-f", env_name)


### PR DESCRIPTION
A few days ago conda 24.3.0 removed `--force` completely causing this to no longer work. `--yes` has been around for more than a year now and we don't really need to support old conda/miniconda so we can just directly replace it and not bother with compatibility with older versions.

https://github.com/conda/conda/releases/tag/24.3.0

Discovered in https://github.com/fal-ai/isolate-cloud/pull/1676 and blocking it.