### PR TITLE
fix(agent): catch BaseException when deserializing user function

### DIFF
--- a/src/isolate/connections/grpc/agent.py
+++ b/src/isolate/connections/grpc/agent.py
@@ -107,10 +107,10 @@ class AgentServicer(definitions.AgentServicer):
             )
 
         try:
-            # TODO: technically any sort of exception could be raised here, since
+            # NOTE: technically any sort of exception could be raised here, since
             # depickling is basically involves code execution from the *user*.
             function = from_grpc(function)
-        except SerializationError as exc:
+        except BaseException as exc:
             return exc, True, traceback.format_exc()
 
         if not callable(function):


### PR DESCRIPTION
We get DeserializationError there now, but really any exception can come up here (see the note), so we can catch BaseException and send it back to the user.