### PR TITLE
chore: print agent logs in addition to sending over grpc

### DIFF
--- a/src/isolate/backends/conda.py
+++ b/src/isolate/backends/conda.py
@@ -171,7 +171,7 @@ class CondaEnvironment(BaseEnvironment[Path]):
 
     def _run_conda(self, *args: Any) -> None:
         conda_executable = get_executable(self._exec_command, self._exec_home)
-        with logged_io(partial(self.log, level=LogLevel.INFO)) as (stdout, stderr):
+        with logged_io(partial(self.log, level=LogLevel.INFO)) as (stdout, stderr, _):
             subprocess.check_call(
                 [conda_executable, *args],
                 stdout=stdout,

--- a/src/isolate/backends/pyenv.py
+++ b/src/isolate/backends/pyenv.py
@@ -80,7 +80,7 @@ class PyenvEnvironment(BaseEnvironment[Path]):
         return Path(prefix.strip())
 
     def _install_python(self, pyenv: Path, root_path: Path) -> None:
-        with logged_io(partial(self.log, level=LogLevel.INFO)) as (stdout, stderr):
+        with logged_io(partial(self.log, level=LogLevel.INFO)) as (stdout, stderr, _):
             try:
                 subprocess.check_call(
                     [pyenv, "install", "--skip-existing", self.python_version],
@@ -102,7 +102,7 @@ class PyenvEnvironment(BaseEnvironment[Path]):
                 return None
 
             pyenv_root = connection_key.parent.parent
-            with logged_io(self.log) as (stdout, stderr):
+            with logged_io(self.log) as (stdout, stderr, _):
                 subprocess.check_call(
                     [pyenv, "uninstall", "-f", connection_key.name],
                     env={**os.environ, "PYENV_ROOT": str(pyenv_root)},

--- a/src/isolate/backends/virtualenv.py
+++ b/src/isolate/backends/virtualenv.py
@@ -110,7 +110,7 @@ class VirtualPythonEnvironment(BaseEnvironment[Path]):
         for extra_index_url in self.extra_index_urls:
             pip_cmd.extend(["--extra-index-url", extra_index_url])
 
-        with logged_io(partial(self.log, level=LogLevel.INFO)) as (stdout, stderr):
+        with logged_io(partial(self.log, level=LogLevel.INFO)) as (stdout, stderr, _):
             try:
                 subprocess.check_call(
                     pip_cmd,

--- a/src/isolate/connections/grpc/_base.py
+++ b/src/isolate/connections/grpc/_base.py
@@ -137,13 +137,17 @@ class LocalPythonGRPC(PythonExecutionBase[str], GRPCExecutionBase):
         self,
         executable: Path,
         connection: str,
+        log_fd: int,
     ) -> List[Union[str, Path]]:
         return [
             executable,
             agent_startup.__file__,
             agent.__file__,
             connection,
+            "--log-fd",
+            str(log_fd),
         ]
 
-    def handle_agent_log(self, line: str, level: LogLevel) -> None:
-        self.log(line, level=level, source=LogSource.USER)
+    def handle_agent_log(self, line: str, level: LogLevel, source: LogSource) -> None:
+        print(f"[{source}] [{level}] {line}")
+        self.log(line, level=level, source=source)


### PR DESCRIPTION
Had to also introduce `--log-fd` mechanism for agents, so we don't have a spaghetti of `Log` message logic in both server and agent (e.g. we were capturing USER logs through logged_io in server, but BRIDGE ones were in agent), which was not allowing this PR to be just  a oneliner `print(log)`.

Note that `--log-fd` mechanism doesn't change anything for the user, same messages are getting sent out, but now from only from server instead of from both server (this is where we were sending out USER logs) and agent (this is where we were sending BRIDGE logs).