### PR TITLE
fix(agent): log exception instead of returning (revert #121)

### DIFF
--- a/src/isolate/connections/grpc/agent.py
+++ b/src/isolate/connections/grpc/agent.py
@@ -112,8 +112,11 @@ class AgentServicer(definitions.AgentServicer):
             # NOTE: technically any sort of exception could be raised here, since
             # depickling is basically involves code execution from the *user*.
             function = from_grpc(function)
-        except BaseException as exc:
-            return exc, True, traceback.format_exc()
+        except BaseException:
+            self.log(traceback.format_exc())
+            raise AbortException(
+                f"The {function_kind} function could not be deserialized."
+            )
 
         if not callable(function):
             raise AbortException(

--- a/src/isolate/connections/grpc/agent.py
+++ b/src/isolate/connections/grpc/agent.py
@@ -10,7 +10,6 @@ from concurrent import futures
 from dataclasses import dataclass
 from typing import (
     Any,
-    Generator,
     Iterable,
     Iterator,
 )
@@ -66,7 +65,7 @@ class AgentServicer(definitions.AgentServicer):
                         self.log(
                             "The setup function has thrown an error. Aborting the run."
                         )
-                        yield from self.send_object(
+                        yield self.send_object(
                             request.setup_func.method,
                             result,
                             was_it_raised,
@@ -74,7 +73,7 @@ class AgentServicer(definitions.AgentServicer):
                         )
                         raise AbortException("The setup function has thrown an error.")
                 except AbortException as exc:
-                    return self.abort_with_msg(context, exc.message)
+                    context.abort(StatusCode.INVALID_ARGUMENT, exc.message)
                 else:
                     assert not was_it_raised
                     self._run_cache[cache_key] = result
@@ -87,14 +86,14 @@ class AgentServicer(definitions.AgentServicer):
                 "function",
                 extra_args=extra_args,
             )
-            yield from self.send_object(
+            yield self.send_object(
                 request.function.method,
                 result,
                 was_it_raised,
                 stringized_tb,
             )
         except AbortException as exc:
-            return self.abort_with_msg(context, exc.message)
+            context.abort(StatusCode.INVALID_ARGUMENT, exc.message)
 
     def execute_function(
         self,
@@ -143,7 +142,7 @@ class AgentServicer(definitions.AgentServicer):
         result: object,
         was_it_raised: bool,
         stringized_tb: str | None,
-    ) -> Generator[definitions.PartialRunResult, None, Any]:
+    ) -> definitions.PartialRunResult:
         try:
             definition = serialize_object(serialization_method, result)
         except SerializationError:
@@ -166,7 +165,7 @@ class AgentServicer(definitions.AgentServicer):
             was_it_raised=was_it_raised,
             stringized_traceback=stringized_tb,
         )
-        yield definitions.PartialRunResult(
+        return definitions.PartialRunResult(
             result=serialized_obj,
             is_complete=True,
             logs=[],
@@ -175,17 +174,6 @@ class AgentServicer(definitions.AgentServicer):
     def log(self, message: str) -> None:
         self._log.write(message)
         self._log.flush()
-
-    def abort_with_msg(
-        self,
-        context: ServicerContext,
-        message: str,
-        *,
-        code: StatusCode = StatusCode.INVALID_ARGUMENT,
-    ) -> None:
-        context.set_code(code)
-        context.set_details(message)
-        return None
 
 
 def create_server(address: str) -> grpc.Server:


### PR DESCRIPTION
We need to keep backward compatibility with older clients and they will have trouble unpickling a new exception, as we are sending these out pickled by reference and not by value (solving that would require serialization backend specific actions, which I would rather avoid for now to unblock a release).