### PR TITLE
chore(grpc): print agent logs in addition to sending over grpc, v2

### DIFF
--- a/src/isolate/backends/conda.py
+++ b/src/isolate/backends/conda.py
@@ -171,7 +171,7 @@ class CondaEnvironment(BaseEnvironment[Path]):
 
     def _run_conda(self, *args: Any) -> None:
         conda_executable = get_executable(self._exec_command, self._exec_home)
-        with logged_io(partial(self.log, level=LogLevel.INFO)) as (stdout, stderr):
+        with logged_io(partial(self.log, level=LogLevel.INFO)) as (stdout, stderr, _):
             subprocess.check_call(
                 [conda_executable, *args],
                 stdout=stdout,

--- a/src/isolate/backends/pyenv.py
+++ b/src/isolate/backends/pyenv.py
@@ -80,7 +80,7 @@ class PyenvEnvironment(BaseEnvironment[Path]):
         return Path(prefix.strip())
 
     def _install_python(self, pyenv: Path, root_path: Path) -> None:
-        with logged_io(partial(self.log, level=LogLevel.INFO)) as (stdout, stderr):
+        with logged_io(partial(self.log, level=LogLevel.INFO)) as (stdout, stderr, _):
             try:
                 subprocess.check_call(
                     [pyenv, "install", "--skip-existing", self.python_version],
@@ -102,7 +102,7 @@ class PyenvEnvironment(BaseEnvironment[Path]):
                 return None
 
             pyenv_root = connection_key.parent.parent
-            with logged_io(self.log) as (stdout, stderr):
+            with logged_io(self.log) as (stdout, stderr, _):
                 subprocess.check_call(
                     [pyenv, "uninstall", "-f", connection_key.name],
                     env={**os.environ, "PYENV_ROOT": str(pyenv_root)},

--- a/src/isolate/backends/virtualenv.py
+++ b/src/isolate/backends/virtualenv.py
@@ -110,7 +110,7 @@ class VirtualPythonEnvironment(BaseEnvironment[Path]):
         for extra_index_url in self.extra_index_urls:
             pip_cmd.extend(["--extra-index-url", extra_index_url])
 
-        with logged_io(partial(self.log, level=LogLevel.INFO)) as (stdout, stderr):
+        with logged_io(partial(self.log, level=LogLevel.INFO)) as (stdout, stderr, _):
             try:
                 subprocess.check_call(
                     pip_cmd,

--- a/src/isolate/connections/grpc/_base.py
+++ b/src/isolate/connections/grpc/_base.py
@@ -136,13 +136,17 @@ class LocalPythonGRPC(PythonExecutionBase[str], GRPCExecutionBase):
         self,
         executable: Path,
         connection: str,
+        log_fd: int,
     ) -> List[Union[str, Path]]:
         return [
             executable,
             agent_startup.__file__,
             agent.__file__,
             connection,
+            "--log-fd",
+            str(log_fd),
         ]
 
-    def handle_agent_log(self, line: str, level: LogLevel) -> None:
-        self.log(line, level=level, source=LogSource.USER)
+    def handle_agent_log(self, line: str, level: LogLevel, source: LogSource) -> None:
+        print(f"[{source}] [{level}] {line}")
+        self.log(line, level=level, source=source)

--- a/src/isolate/connections/grpc/agent.py
+++ b/src/isolate/connections/grpc/agent.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
+import os
+import sys
 import traceback
 from argparse import ArgumentParser
 from concurrent import futures
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import (
     Any,
-    Generator,
     Iterable,
     Iterator,
-    cast,
 )
 
 import grpc
@@ -21,8 +21,7 @@ from isolate.backends.common import sha256_digest_of
 from isolate.connections.common import SerializationError, serialize_object
 from isolate.connections.grpc import definitions
 from isolate.connections.grpc.configuration import get_default_options
-from isolate.connections.grpc.interface import from_grpc, to_grpc
-from isolate.logs import Log, LogLevel, LogSource
+from isolate.connections.grpc.interface import from_grpc
 
 
 @dataclass
@@ -30,16 +29,19 @@ class AbortException(Exception):
     message: str
 
 
-@dataclass
 class AgentServicer(definitions.AgentServicer):
-    _run_cache: dict[str, Any] = field(default_factory=dict)
+    def __init__(self, log_fd: int | None = None):
+        super().__init__()
+
+        self._run_cache: dict[str, Any] = {}
+        self._log = sys.stdout if log_fd is None else os.fdopen(log_fd, "w")
 
     def Run(
         self,
         request: definitions.FunctionCall,
         context: ServicerContext,
     ) -> Iterator[definitions.PartialRunResult]:
-        yield from self.log(f"A connection has been established: {context.peer()}!")
+        self.log(f"A connection has been established: {context.peer()}!")
 
         extra_args = []
         if request.HasField("setup_func"):
@@ -53,16 +55,16 @@ class AgentServicer(definitions.AgentServicer):
                         result,
                         was_it_raised,
                         stringized_tb,
-                    ) = yield from self.execute_function(
+                    ) = self.execute_function(
                         request.setup_func,
                         "setup",
                     )
 
                     if was_it_raised:
-                        yield from self.log(
+                        self.log(
                             "The setup function has thrown an error. Aborting the run."
                         )
-                        yield from self.send_object(
+                        yield self.send_object(
                             request.setup_func.method,
                             result,
                             was_it_raised,
@@ -78,12 +80,12 @@ class AgentServicer(definitions.AgentServicer):
             extra_args.append(self._run_cache[cache_key])
 
         try:
-            result, was_it_raised, stringized_tb = yield from self.execute_function(
+            result, was_it_raised, stringized_tb = self.execute_function(
                 request.function,
                 "function",
                 extra_args=extra_args,
             )
-            yield from self.send_object(
+            yield self.send_object(
                 request.function.method,
                 result,
                 was_it_raised,
@@ -98,7 +100,7 @@ class AgentServicer(definitions.AgentServicer):
         function_kind: str,
         *,
         extra_args: Iterable[Any] = (),
-    ) -> Generator[definitions.PartialRunResult, None, Any]:
+    ) -> tuple[Any, bool, str | None]:
         if function.was_it_raised:
             raise AbortException(
                 f"The {function_kind} function must be callable, "
@@ -110,7 +112,7 @@ class AgentServicer(definitions.AgentServicer):
             # depickling is basically involves code execution from the *user*.
             function = from_grpc(function)
         except SerializationError:
-            yield from self.log(traceback.format_exc(), level=LogLevel.ERROR)
+            self.log(traceback.format_exc())
             raise AbortException(
                 f"The {function_kind} function could not be deserialized."
             )
@@ -121,7 +123,7 @@ class AgentServicer(definitions.AgentServicer):
                 f"not {type(function).__name__}."
             )
 
-        yield from self.log(f"Starting the execution of the {function_kind} function.")
+        self.log(f"Starting the execution of the {function_kind} function.")
 
         was_it_raised = False
         stringized_tb = None
@@ -133,7 +135,7 @@ class AgentServicer(definitions.AgentServicer):
             num_frames = len(traceback.extract_stack()[:-5])
             stringized_tb = "".join(traceback.format_exc(limit=-num_frames))
 
-        yield from self.log(f"Completed the execution of the {function_kind} function.")
+        self.log(f"Completed the execution of the {function_kind} function.")
         return result, was_it_raised, stringized_tb
 
     def send_object(
@@ -142,46 +144,38 @@ class AgentServicer(definitions.AgentServicer):
         result: object,
         was_it_raised: bool,
         stringized_tb: str | None,
-    ) -> Generator[definitions.PartialRunResult, None, Any]:
+    ) -> definitions.PartialRunResult:
         try:
             definition = serialize_object(serialization_method, result)
         except SerializationError:
             if stringized_tb:
-                yield from self.log(
-                    stringized_tb, source=LogSource.USER, level=LogLevel.STDERR
-                )
+                print(stringized_tb, file=sys.stderr)
             raise AbortException(
                 "Error while serializing the execution result "
                 f"(object of type {type(result)})."
             )
         except BaseException:
-            yield from self.log(traceback.format_exc(), level=LogLevel.ERROR)
+            self.log(traceback.format_exc())
             raise AbortException(
                 "An unexpected error occurred while serializing the result."
             )
 
-        yield from self.log("Sending the result.")
+        self.log("Sending the result.")
         serialized_obj = definitions.SerializedObject(
             method=serialization_method,
             definition=definition,
             was_it_raised=was_it_raised,
             stringized_traceback=stringized_tb,
         )
-        yield definitions.PartialRunResult(
+        return definitions.PartialRunResult(
             result=serialized_obj,
             is_complete=True,
             logs=[],
         )
 
-    def log(
-        self,
-        message: str,
-        level: LogLevel = LogLevel.TRACE,
-        source: LogSource = LogSource.BRIDGE,
-    ) -> Iterator[definitions.PartialRunResult]:
-        log = to_grpc(Log(message, level=level, source=source))
-        log = cast(definitions.Log, log)
-        yield definitions.PartialRunResult(result=None, is_complete=False, logs=[log])
+    def log(self, message: str) -> None:
+        self._log.write(message)
+        self._log.flush()
 
     def abort_with_msg(
         self,
@@ -211,10 +205,10 @@ def create_server(address: str) -> grpc.Server:
     return server
 
 
-def run_agent(address: str) -> int:
+def run_agent(address: str, log_fd: int | None = None) -> int:
     """Run the agent servicer on the given address."""
     server = create_server(address)
-    servicer = AgentServicer()
+    servicer = AgentServicer(log_fd=log_fd)
 
     # This function just calls some methods on the server
     # and register a generic handler for the bridge. It does
@@ -229,9 +223,10 @@ def run_agent(address: str) -> int:
 def main() -> int:
     parser = ArgumentParser()
     parser.add_argument("address", type=str)
+    parser.add_argument("--log-fd", type=int)
 
     options = parser.parse_args()
-    return run_agent(options.address)
+    return run_agent(options.address, log_fd=options.log_fd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Additional note about why this will work with old applications (since this is not super trivial): we build multiple environments in server itself with the first one being an agent environment that uses requirements that we pass to it in `AGENT_REQUIREMENTS_TXT`, and this one is built no matter what application you are running and what requirements it might have. Then when spawning an agent and running user code in it, the environment they are running in has a chain of `PYTHONPATH`s that are inherited in an order that makes the first one (so the one from agent requirements txt) override anything after that, which means that no matter what user apps we are running our agent requirements will be the ones uses (including isolate), which makes this PR possible without breaking backward compatibility.

Reapplying #133