### PR TITLE
fix(server): don't reuse ThreadPoolExecutor between grpc and runners

### DIFF
--- a/src/isolate/server/server.py
+++ b/src/isolate/server/server.py
@@ -467,7 +467,7 @@ class LogHandler:
 
 def main() -> None:
     server = grpc.server(
-        RUNNER_THREAD_POOL,
+        futures.ThreadPoolExecutor(max_workers=MAX_THREADS),
         options=get_default_options(),
     )
     with BridgeManager() as bridge_manager:


### PR DESCRIPTION
Probably not the best idea to reuse it, as grpc might do anything that it wishes to it. This is a suspected cause of a `RuntimeError('cannot schedule new futures after shutdown')` that I got during testing submit.