### PR TITLE
fix: don't forget to install flaky

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ test = [
     "pytest",
     "cloudpickle>=2.2.0",
     "dill>=0.3.5.1",
+    "flaky",
 ]
 dev = [
     "isolate[test]",


### PR DESCRIPTION
pytest doesn't have a native `flaky`, need to install it explicitly. Leftover from https://github.com/fal-ai/isolate/pull/163

```
  /Users/runner/work/isolate/isolate/tests/test_server.py:558: PytestUnknownMarkWarning: Unknown pytest.mark.flaky - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
```