### PR TITLE
fix(agent): skip site dirs that have bad .pth files

### DIFF
--- a/src/isolate/connections/_local/agent_startup.py
+++ b/src/isolate/connections/_local/agent_startup.py
@@ -6,6 +6,7 @@ import os
 import runpy
 import site
 import sys
+import traceback
 
 
 def load_pth_files() -> None:
@@ -28,7 +29,13 @@ def load_pth_files() -> None:
     # will need to be fixed once we are dealing with more than 2 nodes and editable
     # packages.
     for site_dir in python_path.split(os.pathsep):
-        site.addsitedir(site_dir)
+        try:
+            site.addsitedir(site_dir)
+        except Exception:
+            # NOTE: there could be .pth files that are model weights and not
+            # python path configuration files.
+            traceback.print_exc()
+            print(f"Error adding site directory {site_dir}, skipping...")
 
 
 def main():


### PR DESCRIPTION
`.pth` could be model weights or python path configuration files https://docs.python.org/3/library/site.html Running into the former will result in:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/isolate/connections/_local/agent_startup.py", line 45, in <module>
    load_pth_files()
  File "/usr/local/lib/python3.11/site-packages/isolate/connections/_local/agent_startup.py", line 31, in load_pth_files
    site.addsitedir(site_dir)
  File "<frozen site>", line 236, in addsitedir
  File "<frozen site>", line 188, in addpackage
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 128: invalid start byte
```

So we are now just skipping such dirs. There is a risk that we might miss some useful pth files, but I doubt there will ever be a situation where two are mixed.