### PR TITLE
feat: install tblib pickling support

### DIFF
--- a/src/isolate/connections/common.py
+++ b/src/isolate/connections/common.py
@@ -7,6 +7,9 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Iterator, cast
 
 from tblib import Traceback, TracebackParseError
+from tblib.pickling_support import install as tblib_install
+
+tblib_install()
 
 if TYPE_CHECKING:
     from typing import Protocol


### PR DESCRIPTION
We are using and installing tblib already, so we should also use it to improve basic exception handling in general, even if our user code didn't manage to patch it yet (e.g. we got a serialization error before we even could run it).